### PR TITLE
Data warnings should note what actually happened to the data

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/InfantMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/InfantMigrator.groovy
@@ -87,7 +87,7 @@ class InfantMigrator extends SqlMigrator {
                     WHEN family_name IS NULL THEN 'family name'
                 END,
                 NULL,
-                'Infant missing name'
+                'Infant missing name. Defaulted to "UNKNOWN"'
             FROM person_name
             WHERE (given_name IS NULL OR family_name IS NULL)
                 AND person_id in (select person_id from hivmigration_infants);

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/PatientMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/PatientMigrator.groovy
@@ -177,7 +177,7 @@ class PatientMigrator extends SqlMigrator {
                     WHEN family_name IS NULL THEN 'family name'
                 END,
                 NULL,
-                'Patient missing name'
+                'Patient missing name. Defaulted to "UNKNOWN"'
             FROM person_name
             WHERE (given_name IS NULL OR family_name IS NULL)
                 AND person_id in (select person_id from hivmigration_patients);
@@ -216,7 +216,7 @@ class PatientMigrator extends SqlMigrator {
         ''')
         executeMysql("Note long addresses", '''
             INSERT INTO hivmigration_data_warnings (patient_id, field_name, field_value, note)
-            SELECT p.person_id, 'address', pa.address, 'Address exceeds 255 character limit'
+            SELECT p.person_id, 'address', pa.address, 'Address too long. Truncated to 255 characters.'
             FROM  hivmigration_patient_addresses pa, hivmigration_patients p
             WHERE pa.source_patient_id = p.source_patient_id AND LENGTH(pa.address) > 255;
         ''')


### PR DESCRIPTION
PR for informational purposes—Dave asked that the warnings data answer the question "What was actually done with the data?"

Trivial; merging.