### PR TITLE
UHM-5046, update data type mapping

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/StagingTablesMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/StagingTablesMigrator.groovy
@@ -3,6 +3,7 @@ package org.pih.hivmigration.etl.sql
 class StagingTablesMigrator extends SqlMigrator {
     @Override
     def void migrate() {
+        (new TableStager("HIV_TB_STATUS")).migrate()
         (new TableStager("HIV_INTAKE_FORMS")).migrate()
         (new TableStager("HIV_FOLLOWUP_FORMS")).migrate()
         (new TableStager("HIV_DIAGNOSES")).migrate()
@@ -29,5 +30,6 @@ class StagingTablesMigrator extends SqlMigrator {
         (new TableStager("HIV_DIAGNOSES")).revert()
         (new TableStager("HIV_FOLLOWUP_FORMS")).revert()
         (new TableStager("HIV_INTAKE_FORMS")).revert()
+        (new TableStager("HIV_TB_STATUS")).revert()
     }
 }


### PR DESCRIPTION
I had to update the data mapping to be a bit more precise. Before this change, the ORACLE CHAR(8) data type was mapped to MySQL CHAR which caused the migration to fail because it could not insert 8 chars strings into 1 char field. Now, I added the DATA_LENGTH when defining the MySQL data type.