### PR TITLE
Restore and fix: Create registration encounter for each infant

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/InfantMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/InfantMigrator.groovy
@@ -120,7 +120,7 @@ class InfantMigrator extends SqlMigrator {
               hivmigration_infants i
         ''')
 
-        // log birthdates in the future or birthdates older than 120 years
+        // log birthdates that are null, in the future, or older than 30 years
         executeMysql("Log abnormal birthdate values", '''
                 insert into hivmigration_data_warnings (                    
                     openmrs_patient_id,
@@ -131,11 +131,12 @@ class InfantMigrator extends SqlMigrator {
                 select
                 	p.person_id as openmrsPatientId,                     
                     'birthdate' as fieldName,
-                    p.birthdate as fieldValue, 
-                    'Abnormal birthdate value' as warningType,                    
-                    1 			
+                    p.birthdate as fieldValue,
+                    'Abnormal birthdate value' as warningType,
+                    1
                 from person p 
-                where (p.person_id in (select person_id from hivmigration_infants)) and (birthdate is not null  and (birthdate > now() || birthdate < (SELECT DATE_SUB(now(), INTERVAL 120 YEAR)))); 
+                where (p.person_id in (select person_id from hivmigration_infants))
+                    and (birthdate is null OR birthdate > now() OR birthdate < (SELECT DATE_SUB(now(), INTERVAL 30 YEAR))); 
         ''')
 
         // TODO: see https://pihemr.atlassian.net/browse/UHM-4817
@@ -178,6 +179,23 @@ class InfantMigrator extends SqlMigrator {
             from
               hivmigration_infants i
             order by i.source_infant_id;
+        ''')
+
+        executeMysql("Create empty registration encounter for each infant", '''
+            INSERT INTO encounter
+                (encounter_type, patient_id, location_id, form_id, encounter_datetime, creator, date_created, voided, uuid)
+            SELECT
+                (SELECT encounter_type_id FROM encounter_type WHERE name = 'Enregistrement de patient'),
+                person_id,
+                hhc.openmrs_id,
+                (SELECT form_id FROM form WHERE uuid = '6F6E6FA0-1E99-41A3-9391-E5CB8A127C11'),
+                IFNULL(birthdate, now()),
+                1,
+                now(),
+                0,
+                uuid()
+            FROM hivmigration_infants i
+            LEFT JOIN hivmigration_health_center hhc ON i.health_center = hhc.hiv_emr_id;
         ''')
 
         executeMysql("Load ZL IDs", '''

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
@@ -105,10 +105,10 @@ public class Migrator {
                 revert(new EncounterMigrator());
                 revert(new ProviderMigrator());
                 revert(new ProgramMigrator());
-                revert(new LocationMigrator());
                 revert(new RegistrationMigrator());
                 revert(new InfantMigrator());
                 revert(new PatientMigrator());
+                revert(new LocationMigrator());
                 revert(new StagingTablesMigrator());
                 revert(new UserMigrator());
                 revert(new Setup());
@@ -117,10 +117,10 @@ public class Migrator {
                 migrate(new Setup(), -1);
                 migrate(new UserMigrator(), -1);
                 migrate(new StagingTablesMigrator(), -1);
+                migrate(new LocationMigrator(), -1);
                 migrate(new PatientMigrator(), limit);
                 migrate(new InfantMigrator(), limit);
                 migrate(new RegistrationMigrator(), limit);
-                migrate(new LocationMigrator(), -1);
                 migrate(new ProgramMigrator(), limit);
                 migrate(new ProviderMigrator(), limit);
                 migrate(new EncounterMigrator(), limit);


### PR DESCRIPTION
This reverts commit fe6ddb5ea1ff2a0dc74fb6fe0dc2ac9a8ace719a, restoring the original commit.

The problem was that the Location migrator was running after the Infant migrator.