### PR TITLE
UHM-5097 Migrate HIV_SOCIOECOMICS (part 2) and HIV_SOCOECONOMICS_EXTRA

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
@@ -104,10 +104,10 @@ public class Migrator {
                 revert(new FormsMigrator());
                 revert(new LabResultMigrator());
                 revert(new AdverseEventMigrator());
-                revert(new EncounterMigrator());
                 revert(new ProviderMigrator());
                 revert(new ProgramMigrator());
                 revert(new RegistrationMigrator());
+                revert(new EncounterMigrator());
                 revert(new InfantMigrator());
                 revert(new PatientMigrator());
                 revert(new LocationMigrator());
@@ -122,10 +122,10 @@ public class Migrator {
                 migrate(new StagingTablesMigrator(), limit);
                 migrate(new PatientMigrator(), limit);
                 migrate(new InfantMigrator(), limit);
+                migrate(new EncounterMigrator(), limit);
                 migrate(new RegistrationMigrator(), limit);
                 migrate(new ProgramMigrator(), limit);
                 migrate(new ProviderMigrator(), limit);
-                migrate(new EncounterMigrator(), limit);
                 migrate(new AdverseEventMigrator(), limit);
                 migrate(new LabResultMigrator(), limit);
                 migrate(new FormsMigrator(), limit);

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
@@ -102,6 +102,7 @@ public class Migrator {
                 revert(new HivExamsMigrator());
                 revert(new PreviousExposureMigrator());
                 revert(new FormsMigrator());
+                revert(new SocioEconomicsMigrator());
                 revert(new LabResultMigrator());
                 revert(new AdverseEventMigrator());
                 revert(new ProviderMigrator());
@@ -128,6 +129,7 @@ public class Migrator {
                 migrate(new ProviderMigrator(), limit);
                 migrate(new AdverseEventMigrator(), limit);
                 migrate(new LabResultMigrator(), limit);
+                migrate(new SocioEconomicsMigrator(), limit);
                 migrate(new FormsMigrator(), limit);
                 migrate(new PreviousExposureMigrator(), limit);
                 migrate(new VitalsMigrator(), limit);

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/RegistrationMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/RegistrationMigrator.groovy
@@ -1,6 +1,6 @@
 package org.pih.hivmigration.etl.sql
 
-class RegistrationMigrator extends SqlMigrator {
+class RegistrationMigrator extends ObsMigrator {
 
     @Override
     def void migrate() {
@@ -25,29 +25,6 @@ class RegistrationMigrator extends SqlMigrator {
                 commune NVARCHAR(100),
                 section NVARCHAR(100),
                 locality NVARCHAR(100)
-            );
-        ''')
-
-        executeMysql("Create Patient Socio-Economics Staging Table",
-                '''
-            create table hivmigration_socio_economics (    
-                obs_id int PRIMARY KEY AUTO_INCREMENT,                            
-                source_patient_id int,                                
-                civil_status NVARCHAR(16),
-                primary_activity NVARCHAR(96),
-                other_sexual_partners text,
-                partners_same_town_p char(1) DEFAULT NULL,
-                partners_other_town text,
-                residences text,                
-                nutritional_evaluation text,
-                num_people_in_house decimal(10,0) DEFAULT NULL,
-                num_rooms_in_house decimal(10,0) DEFAULT NULL,
-                type_of_roof text,
-                type_of_floor text,
-                latrine_p char(1) DEFAULT NULL,
-                radio_p char(1) DEFAULT NULL,
-                education text,
-                other_sexual_partners_p char(1) DEFAULT NULL
             );
         ''')
 
@@ -90,51 +67,13 @@ class RegistrationMigrator extends SqlMigrator {
                     l.section_communale as section,
                     nvl(l.locality, d.BIRTH_PLACE) as locality
                 from HIV_DEMOGRAPHICS_REAL d left outer join hiv_locality l
-                     on d.BIRTH_PLACE_LOCALITY = l.locality_id 
-            ''');
-
-        // load patients CIVIL_STATUS and OCCUPATION into the staging table
-        loadFromOracleToMySql('''
-                    insert into hivmigration_socio_economics(
-                        source_patient_id,                         
-                        civil_status, 
-                        primary_activity,
-                        other_sexual_partners,
-                        partners_same_town_p,
-                        partners_other_town,
-                        residences,                
-                        nutritional_evaluation,
-                        num_people_in_house,
-                        num_rooms_in_house,
-                        type_of_roof,
-                        type_of_floor,
-                        latrine_p,
-                        radio_p,
-                        education,
-                        other_sexual_partners_p)
-                    values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-            ''',
-                '''
-                    select 
-                        s.patient_id as source_patient_id, 
-                        UPPER(TRIM(s.civil_status)) as civil_status, 
-                        UPPER(TRIM(s.PRIMARY_ACTIVITY)) as primary_activity,
-                        s.other_sexual_partners,
-                        s.partners_same_town_p,
-                        s.partners_other_town,
-                        s.residences,                
-                        s.nutritional_evaluation,
-                        s.num_people_in_house,
-                        s.num_rooms_in_house,
-                        s.type_of_roof,
-                        s.type_of_floor,
-                        s.latrine_p,
-                        s.radio_p,
-                        s.education,
-                        s.other_sexual_partners_p 
-                    from HIV_SOCIOECONOMICS s, hiv_demographics_real p 
-                    where (s.patient_id = p.patient_id) and ((s.civil_status is not null) or (s.PRIMARY_ACTIVITY is not null)) order by s.patient_id;
-            ''');
+                     on d.BIRTH_PLACE_LOCALITY = l.locality_id
+                where l.department is not null
+                    or l.commune is not null 
+                    or l.section_communale is not null 
+                    or l.locality is not null 
+                    or d.BIRTH_PLACE is not null;
+        ''')
 
         executeMysql("Create Registration encounters",'''
 
@@ -162,181 +101,122 @@ class RegistrationMigrator extends SqlMigrator {
                     r.creator,
                     1    
             from hivmigration_registration_encounters r, hivmigration_patients p
-            where r.source_patient_id = p.source_patient_id;                                                                                      
+            where r.source_patient_id = p.source_patient_id;
+            
+            update hivmigration_patient_birthplace b
+            join hivmigration_patients hp on b.source_patient_id = hp.source_patient_id
+            join encounter e on hp.person_id = e.patient_id and e.encounter_type = @encounter_type_registration
+            set b.encounter_id = e.encounter_id;
         ''')
 
+        create_tmp_obs_table()
 
         executeMysql("Load birthplaces as obs",'''
 
-            -- Create Birthplace address construct
-            SET @birthplace_construct = (concept_from_mapping('PIH', 'Birthplace address construct'));
+            ALTER TABLE hivmigration_patient_birthplace ADD COLUMN encounter_date DATETIME;
             
-            INSERT INTO obs (
-                    obs_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,                    
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @birthplace_construct,
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and ( b.locality is not null or b.section is not null or b.commune is not null or b.department is not null); 
-                    
+            UPDATE hivmigration_patient_birthplace b
+            JOIN hivmigration_registration_encounters e ON b.encounter_id = e.encounter_id
+            SET b.encounter_date = e.encounter_date;
+            
+            -- Create Birthplace address construct
+            INSERT INTO tmp_obs (
+                obs_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'Birthplace address construct')
+            from    hivmigration_patient_birthplace b
+            where locality is not null or section is not null or commune is not null or department is not null;
+            
             -- Add Locality
-            SET @locality_concept = (concept_from_mapping('PIH', 'Address1'));  
-            INSERT INTO obs (
-                    obs_group_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,    
-                    value_text,                
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @locality_concept,
-                    b.locality,
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and b.locality is not null;     
-                    
+            INSERT INTO tmp_obs (
+                obs_group_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid,
+                value_text)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'Address1'),
+                locality
+            from    hivmigration_patient_birthplace
+            where   locality is not null;
+            
             -- Add Section Communale
-            SET @section_communale_concept = (concept_from_mapping('PIH', 'Address3'));  
-            INSERT INTO obs (
-                    obs_group_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,    
-                    value_text,                
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @section_communale_concept,
-                    b.section,
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and b.section is not null; 
-                    
-                    
+            INSERT INTO tmp_obs (
+                obs_group_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid,
+                value_text)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'Address3'),
+                section
+            from    hivmigration_patient_birthplace
+            where   section is not null;
+            
+            
             -- Add Commune
-            SET @commune_concept = (concept_from_mapping('PIH', 'City Village'));  
-            INSERT INTO obs (
-                    obs_group_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,    
-                    value_text,                
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @commune_concept,
-                    b.commune,
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and b.commune is not null;   
-                    
+            INSERT INTO tmp_obs (
+                obs_group_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid,
+                value_text)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'City Village'),
+                commune
+            from    hivmigration_patient_birthplace
+            where   commune is not null;
+            
             -- Add Department
-            SET @department_concept = (concept_from_mapping('PIH', 'State Province'));  
-            INSERT INTO obs (
-                    obs_group_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,    
-                    value_text,                
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @department_concept,
-                    b.department,
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and b.department is not null;  
-                    
+            INSERT INTO tmp_obs (
+                obs_group_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid,
+                value_text)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'State Province'),
+                department
+            from    hivmigration_patient_birthplace
+            where   department is not null;
+            
             -- Add Country
-            SET @country_concept = (concept_from_mapping('PIH', 'Country'));  
-            INSERT INTO obs (
-                    obs_group_id,
-                    person_id, 
-                    encounter_id, 
-                    obs_datetime, 
-                    location_id, 
-                    concept_id,    
-                    value_text,                
-                    creator, 
-                    date_created, 
-                    uuid)
-            select   
-                    b.obs_id, 
-                    p.person_id,
-                    r.encounter_id,
-                    r.encounter_date,
-                    1 as locationId,
-                    @country_concept,
-                    'Haiti',
-                    r.creator,
-                    r.encounter_date as dateCreated,
-                    uuid() as uuid
-            from    hivmigration_patient_birthplace b,  hivmigration_registration_encounters r, hivmigration_patients p 
-            where   b.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id 
-                    and ( b.locality is not null or b.section is not null or b.commune is not null or b.department is not null);       
-                    
-                    
+            INSERT INTO tmp_obs (
+                obs_group_id,
+                encounter_id,
+                obs_datetime,
+                concept_uuid,
+                value_text)
+            select
+                obs_id,
+                encounter_id,
+                encounter_date,
+                concept_uuid_from_mapping('PIH', 'Country'),
+                'Haiti'
+            from    hivmigration_patient_birthplace;
+        ''')
+
+        migrate_tmp_obs()
+
+        executeMysql("Add civil status obs", '''
             -- Add CIVIL STATUS
             SET @civil_status_concept = (concept_from_mapping('PIH', 'CIVIL STATUS'));
               
@@ -356,7 +236,7 @@ class RegistrationMigrator extends SqlMigrator {
                     r.encounter_date as obs_datetime, 
                     1 as locationId, 
                     @civil_status_concept as concept_id,  
-                    CASE s.civil_status 
+                    CASE UPPER(TRIM(s.civil_status)) 
                         WHEN 'DIVORCED' THEN concept_from_mapping('PIH', 'DIVORCED') 
                         WHEN 'MARRIED' THEN concept_from_mapping('PIH', 'MARRIED') 
                         WHEN 'PARTNER' THEN concept_from_mapping('PIH', 'LIVING WITH PARTNER') 
@@ -367,8 +247,8 @@ class RegistrationMigrator extends SqlMigrator {
                         ELSE concept_from_mapping('PIH', 'OTHER') 
                     END as value_coded, 
                     r.creator, r.encounter_date as dateCreated, uuid() as uuid
-            from hivmigration_socio_economics s, hivmigration_registration_encounters r, hivmigration_patients p 
-            where  s.civil_status is not null and s.source_patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id;                                                                                                                                                                                                     
+            from hivmigration_socioeconomics s, hivmigration_registration_encounters r, hivmigration_patients p 
+            where  s.civil_status is not null and s.patient_id = r.source_patient_id and r.source_patient_id = p.source_patient_id;                                                                                                                                                                                                     
         ''')
 
     }
@@ -379,7 +259,6 @@ class RegistrationMigrator extends SqlMigrator {
             executeMysql("delete from obs where (encounter_id in (select encounter_id from hivmigration_registration_encounters)) and (obs_group_id is not null)")
             executeMysql("delete from obs where encounter_id in (select encounter_id from hivmigration_registration_encounters)")
             executeMysql("delete from encounter where encounter_id in (select encounter_id from hivmigration_registration_encounters)")
-            executeMysql("drop table if exists hivmigration_socio_economics")
             executeMysql("drop table if exists hivmigration_patient_birthplace")
             executeMysql("drop table if exists hivmigration_registration_encounters")
         }

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/SocioEconomicsMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/SocioEconomicsMigrator.groovy
@@ -3,25 +3,139 @@ package org.pih.hivmigration.etl.sql
 class SocioEconomicsMigrator extends ObsMigrator {
     @Override
     def void migrate() {
-        // loaded by StagingTablesMigrator
+        // hivmigration_socioeconomics and hivmigration_socioeconomics_extra loaded by StagingTablesMigrator
 
         create_tmp_obs_table()
 
-        executeMysql("Add source_encounter_id to staged table", '''
-            ALTER TABLE hivmigration_socioeconomics_extra
-            ADD COLUMN source_encounter_id INT;
+        executeMysql("Create socioeconomics encounters", '''            
+            insert into encounter
+                (encounter_datetime, date_created, encounter_type, form_id, patient_id, creator, location_id, uuid)
+            select intake.encounter_date,
+                   intake.date_created,
+                   (select encounter_type_id from encounter_type where name = 'Socio-economics'),
+                   (select form_id from form where name = 'Socioeconomics Note'),
+                   p.person_id,
+                   1,
+                   ifnull(intake.location_id, 1),
+                   uuid()
+            from hivmigration_socioeconomics s
+            join hivmigration_patients p on s.patient_id = p.source_patient_id
+            join hivmigration_encounters intake on p.source_patient_id = intake.source_patient_id and intake.source_encounter_type = 'intake\'
+            where s.num_rooms_in_house is not null
+               or s.num_people_in_house is not null
+               or s.latrine_p is not null
+               or s.radio_p is not null
+               or s.education is not null
+               or s.type_of_floor is not null
+               or s.type_of_roof is not null;
+               
+            insert into encounter
+                (encounter_datetime, date_created, encounter_type, form_id, patient_id, creator, location_id, uuid)
+            select intake.encounter_date,
+                   intake.date_created,
+                   (select encounter_type_id from encounter_type where name = 'Socio-economics'),
+                   (select form_id from form where name = 'Socioeconomics Note'),
+                   p.person_id,
+                   1,
+                   ifnull(intake.location_id, 1),
+                   uuid()
+            from hivmigration_socioeconomics_extra s
+            join hivmigration_patients p on s.patient_id = p.source_patient_id
+            join hivmigration_encounters intake on p.source_patient_id = intake.source_patient_id and intake.source_encounter_type = 'intake\'
+            where s.method_of_transport is not null
+               or s.walking_time_to_clinic is not null
+               or s.time_of_transport is not null
+               or s.arrival_method_other is not null;
+        ''')
+
+        executeMysql("Add encounter IDs to socioeconomics and socioeconomics_extra tables", '''
+            ALTER TABLE hivmigration_socioeconomics ADD COLUMN socioecon_encounter_id INT;            
+            ALTER TABLE hivmigration_socioeconomics_extra ADD COLUMN intake_encounter_id INT;
             
+            -- Add socioeconomics encounter ids to socioeconomics
+            UPDATE hivmigration_socioeconomics hs
+            JOIN encounter e
+                ON hs.patient_id = e.patient_id
+                AND e.encounter_type = (select encounter_type_id from encounter_type where name = 'Socio-economics')
+            SET hs.socioecon_encounter_id = e.encounter_id;
+
+            -- Add intake encounter ids to socioeconomics_extra
             UPDATE hivmigration_socioeconomics_extra hse
             JOIN hivmigration_encounters he
                 ON hse.patient_id = he.patient_id
                 AND he.source_encounter_type = 'intake'
-            SET source_encounter_id = he.source_encounter_id;
+            SET hse.intake_encounter_id = he.encounter_id;
         ''')
 
-        executeMysql("Migrate tobacco and alcohol use", '''
+        executeMysql("Migrate fields from socioeconomics table into socioeconomics form", '''
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_coded_uuid)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('CIEL', '1474'),
+                   num_people_in_house
+            FROM hivmigration_socioeconomics
+            WHERE num_people_in_house IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('CIEL', '1475'),
+                   num_rooms_in_house
+            FROM hivmigration_socioeconomics
+            WHERE num_rooms_in_house IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('PIH', 'ROOF MATERIAL'),
+                   CASE type_of_roof
+                       WHEN 'concrete' THEN concept_uuid_from_mapping('PIH', 'CEMENT')
+                       WHEN 'sheet' THEN concept_uuid_from_mapping('PIH', 'SHEET METAL')
+                       WHEN 'thatch' THEN concept_uuid_from_mapping('PIH', 'THATCH')
+                       WHEN 'tile' THEN concept_uuid_from_mapping('CIEL', '159679')  -- ceramic tile (not on new form)
+                       WHEN 'tin' THEN concept_uuid_from_mapping('PIH', 'SHEET METAL')
+                       END
+            FROM hivmigration_socioeconomics
+            WHERE type_of_roof IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('PIH', 'ROOF MATERIAL'),
+                   CASE type_of_floor
+                       WHEN 'beaten ground' THEN concept_uuid_from_mapping('PIH', 'BEATEN EARTH')
+                       WHEN 'cement' THEN concept_uuid_from_mapping('PIH', 'CEMENT')
+                       WHEN 'dirt' THEN concept_uuid_from_mapping('PIH', 'OTHER')
+                       WHEN 'mud' THEN concept_uuid_from_mapping('PIH', 'OTHER')
+                       END
+            FROM hivmigration_socioeconomics
+            WHERE type_of_floor IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('PIH', 'Latrine'),
+                   IF( latrine_p = 't',
+                       concept_uuid_from_mapping('PIH', 'YES'),
+                       concept_uuid_from_mapping('PIH', 'NO'))
+            FROM hivmigration_socioeconomics
+            WHERE latrine_p IN ('t', 'f');
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT socioecon_encounter_id,
+                   concept_uuid_from_mapping('PIH', '1318'),
+                   IF( radio_p = 't',
+                       concept_uuid_from_mapping('PIH', 'YES'),
+                       concept_uuid_from_mapping('PIH', 'NO'))
+            FROM hivmigration_socioeconomics
+            WHERE radio_p IN ('t', 'f');
+        ''')
+
+        executeMysql("Migrate fields from socioeconomics_extra table into intake form", '''
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('CIEL', '163731'),
                    IF( smokes_p = 't',
                        concept_uuid_from_mapping('PIH', 'CURRENTLY'),
@@ -30,44 +144,94 @@ class SocioEconomicsMigrator extends ObsMigrator {
             WHERE smokes_p IN ('t', 'f');
             
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_numeric)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('CIEL', '159931'),
                    trim(smoking_years)
             FROM hivmigration_socioeconomics_extra
             WHERE smoking_years IS NOT NULL;
             
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_numeric)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('PIH', '11949'),
                    trim(num_cigarretes_per_day)
             FROM hivmigration_socioeconomics_extra
             WHERE num_cigarretes_per_day IS NOT NULL;
             
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_coded_uuid)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('CIEL', '159449'),
                    concept_uuid_from_mapping('PIH', 'CURRENTLY')
             FROM hivmigration_socioeconomics_extra
             WHERE num_days_alcohol_per_week > 0 OR beer_per_day > 0 OR wine_per_day > 0 OR drinks_per_day > 0;
             
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_numeric)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('PIH', '2243'),
                    trim(num_days_alcohol_per_week)
             FROM hivmigration_socioeconomics_extra
             WHERE num_days_alcohol_per_week IS NOT NULL;
             
             INSERT INTO tmp_obs
-                (source_encounter_id, concept_uuid, value_numeric)
-            SELECT source_encounter_id,
+                (encounter_id, concept_uuid, value_numeric)
+            SELECT intake_encounter_id,
                    concept_uuid_from_mapping('PIH', '2246'),
                    (IFNULL(trim(wine_per_day), 0) + IFNULL(trim(beer_per_day), 0) + IFNULL(trim(drinks_per_day), 0))
             FROM hivmigration_socioeconomics_extra
             WHERE wine_per_day IS NOT NULL OR beer_per_day IS NOT NULL OR drinks_per_day IS NOT NULL;
+        ''')
+
+        executeMysql("Migrate fields from socioeconomics_extra table into socioeconomics form", '''
+            SET @socioecon_encounter_type = (select encounter_type_id from encounter_type where name = 'Socio-economics');
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT e.encounter_id,
+                   concept_uuid_from_mapping('PIH', '975'),
+                   CASE method_of_transport
+                       WHEN ' bus' THEN concept_uuid_from_mapping('PIH', 'MINI BUS')
+                       WHEN 'bicycle' THEN concept_uuid_from_mapping('PIH', 'BY BICYCLE')
+                       WHEN 'car' THEN concept_uuid_from_mapping('PIH', 'CAR')
+                       WHEN 'foot' THEN concept_uuid_from_mapping('PIH', 'WALKING')
+                       WHEN 'horse' THEN concept_uuid_from_mapping('PIH', '980')
+                       WHEN 'horse_mule' THEN concept_uuid_from_mapping('PIH', '980')
+                       WHEN 'minibus' THEN concept_uuid_from_mapping('PIH', 'MINI BUS')
+                       WHEN 'other' THEN concept_uuid_from_mapping('PIH', 'OTHER')
+                       WHEN 'stretcher' THEN concept_uuid_from_mapping('PIH', 'STRETCHER')
+                       WHEN 'walk' THEN concept_uuid_from_mapping('PIH', 'WALKING')
+                       END
+            FROM hivmigration_socioeconomics_extra hse
+            JOIN encounter e ON hse.patient_id = e.patient_id AND e.encounter_type = @socioecon_encounter_type
+            WHERE method_of_transport IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_coded_uuid)
+            SELECT e.encounter_id,
+                   concept_uuid_from_mapping('PIH', 'CLINIC TRAVEL TIME'),
+                   CASE IFNULL(time_of_transport, walking_time_to_clinic)
+                        WHEN 'under_30_min' THEN concept_uuid_from_mapping('PIH', 'LESS THAN 30 MINUTES')
+                        WHEN '30_min_to_1_hour' THEN concept_uuid_from_mapping('PIH', '30 TO 60 MINUTES')
+                        WHEN '1_to_2_hours' THEN concept_uuid_from_mapping('PIH', 'ONE TO TWO HOURS')
+                        WHEN '2_to_3_hours' THEN concept_uuid_from_mapping('PIH', '982')  -- 2-3 hours
+                        WHEN '3_to_6_hours' THEN concept_uuid_from_mapping('PIH', '3669')  -- >3 hours
+                        WHEN 'over_6_hours' THEN concept_uuid_from_mapping('PIH', '3669')  -- >3 hours
+                        WHEN 'unknown' THEN concept_uuid_from_mapping('PIH', 'UNKNOWN')
+                        END
+            FROM hivmigration_socioeconomics_extra hse
+            JOIN encounter e ON hse.patient_id = e.patient_id AND e.encounter_type = @socioecon_encounter_type
+            WHERE walking_time_to_clinic IS NOT NULL OR time_of_transport IS NOT NULL;
+            
+            INSERT INTO tmp_obs
+                (encounter_id, concept_uuid, value_text)
+            SELECT e.encounter_id,
+                   concept_uuid_from_mapping('PIH', '1301'),  -- comment
+                   arrival_method_other
+            FROM hivmigration_socioeconomics_extra hse
+            JOIN encounter e ON hse.patient_id = e.patient_id AND e.encounter_type = @socioecon_encounter_type
+            WHERE arrival_method_other IS NOT NULL;
         ''')
 
         migrate_tmp_obs()

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/SocioEconomicsMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/SocioEconomicsMigrator.groovy
@@ -240,6 +240,9 @@ class SocioEconomicsMigrator extends ObsMigrator {
 
     @Override
     def void revert() {
-
+        executeMysql("ALTER TABLE hivmigration_socioeconomics DROP COLUMN socioecon_encounter_id;");
+        executeMysql("ALTER TABLE hivmigration_socioeconomics_extra DROP COLUMN intake_encounter_id;")
+        clearTable("obs")
+        executeMysql("DELETE FROM encounter WHERE encounter_type = (select encounter_type_id from encounter_type where name = 'Socio-economics');")
     }
 }

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/StagingTablesMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/StagingTablesMigrator.groovy
@@ -16,6 +16,7 @@ class StagingTablesMigrator extends SqlMigrator {
         migrateTable("HIV_PATIENT_OBS")
         migrateTable("HIV_COURSE_OF_TX")
         migrateTable("HIV_SOCIAL_SUPPORT")
+        migrateTable("HIV_SOCIOECONOMICS")
         migrateTable("HIV_SOCIOECONOMICS_EXTRA")
     }
     
@@ -28,6 +29,7 @@ class StagingTablesMigrator extends SqlMigrator {
     @Override
     def void revert() {
         revertTable("HIV_SOCIOECONOMICS_EXTRA")
+        revertTable("HIV_SOCIOECONOMICS")
         revertTable("HIV_SOCIAL_SUPPORT")
         revertTable("HIV_COURSE_OF_TX")
         revertTable("HIV_PATIENT_OBS")

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/WhoStagingCriteriaMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/WhoStagingCriteriaMigrator.groovy
@@ -7,7 +7,6 @@ class WhoStagingCriteriaMigrator extends ObsMigrator {
         executeMysql("Create staging table for HIV_EXAM_WHO_STAGING_CRITERIA", '''
             create table hivmigration_hiv_who_staging (                                          
               source_encounter_id int,
-              source_patient_id int,
               criterium VARCHAR(72)    
             );
         ''')
@@ -15,14 +14,12 @@ class WhoStagingCriteriaMigrator extends ObsMigrator {
         loadFromOracleToMySql('''
             insert into hivmigration_hiv_who_staging (
               source_encounter_id,
-              source_patient_id,
               criterium
             )
-            values(?,?,?) 
+            values(?,?) 
             ''', '''
             SELECT 
                 w.ENCOUNTER_ID as source_encounter_id, 
-                e.patient_id as source_patient_id, 
                 w.CRITERIUM 
             from HIV_EXAM_WHO_STAGING_CRITERIA w, hiv_encounters e, hiv_demographics_real d 
             where w.CRITERIUM is not null and w.ENCOUNTER_ID = e.ENCOUNTER_ID and e.patient_id = d.patient_id;
@@ -88,12 +85,10 @@ class WhoStagingCriteriaMigrator extends ObsMigrator {
         executeMysql("Load WHO Clinical Staging observations", '''
 
             INSERT INTO tmp_obs (
-                source_patient_id,
                 source_encounter_id,
                 concept_uuid,
                 value_coded_uuid)
             select 
-                s.source_patient_id, 
                 s.source_encounter_id,  
                 concept_uuid_from_mapping('CIEL', '6042') as concept_uuid,
                 concept_uuid_from_mapping(m.openmrs_concept_source, m.openmrs_concept_code) as value_coded_uuid


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/UHM-5097

This is sort of a big one. I refactored `migrate_tmp_obs`. Now you can specify either `source_encounter_id` or `encounter_id` for obs. Also, the `source_patient_id` field is now ignored. This makes it easier to create obs for which the encounter does not correspond to anything in `hivmigration_encounters`.

I also refactored the RegistrationMigration, reducing its run time from ~10 mins to ~3 mins (for `-l=100000`).