### PR TITLE
Part 2 of UHM-5090 Migrate current_tx.tb_other observation

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/TreatmentObsMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/TreatmentObsMigrator.groovy
@@ -460,10 +460,10 @@ class TreatmentObsMigrator extends ObsMigrator {
                 source_encounter_id,
                 concept_uuid_from_mapping('CIEL', '159798'),
                 IF(value != 'none',
-                    concept_uuid_from_mapping('CIEL', '1065'),
-                    concept_uuid_from_mapping('CIEL', '1066')) 
+                    concept_uuid_from_mapping('PIH', 'YES'),
+                    concept_uuid_from_mapping('PIH', 'NO')) 
             FROM hivmigration_observations
-            WHERE observation = 'current_tx.tb';
+            WHERE observation IN ('current_tx.tb', 'current_tx.tb_other');
         ''')
 
         executeMysql("Migrate TB treatment start date", '''
@@ -496,10 +496,15 @@ class TreatmentObsMigrator extends ObsMigrator {
             SELECT
                 source_encounter_id,
                 concept_uuid_from_mapping('CIEL', '1111'),
-                concept_uuid_from_mapping('PIH', '2406')  -- TB initial treatment with 2HRZE/4HR
+                CASE value
+                    WHEN 'Retraitement 2RHEZ/4RH' THEN concept_uuid_from_mapping('PIH', '2408')  -- TB retreatment with 2 RHZE / 4 RH 
+                    ELSE concept_uuid_from_mapping('PIH', '2406')  -- TB initial treatment with 2HRZE/4HR
+                    END
             FROM hivmigration_observations
             WHERE observation = 'current_tx.tb_other'
-                AND value IN ('Premier 2HZRE+4HR', '2HZRE+4HR', '4RH', '4HR', '4 hr', '+ 4HR', '2HZRE + 4 HR.', 'RHEZ', '2HRZE + 4HR');
+                AND value IN ('Premier 2HZRE+4HR', '2HZRE+4HR', '4RH', '4HR', '4 hr', '+ 4HR',
+                              '2HZRE + 4 HR.', 'RHEZ', '2HRZE + 4HR', '2HZRE + 4 HR', ' 2 HZRE + 4 HR',
+                              'Retraitement 2RHEZ/4RH');
         ''')
 
         migrate_tmp_obs()


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/UHM-5090

Addresses Mark's feedback:

> I agree with not mapping “Retraitement 2RHEZ/4RH” to “initial”, but shouldn’t it be mapped to “Retreatment: 2HRZE / 4HR“ (see patient 104145, followup encounter on Oct 30, 2019)
>
> I’m not seeing the mapping working properly for “2HZRE + 4 HR”, see patient 96440, encounter on Nov 4, 2020, or patient 94434, encounter on Oct 28, 2016… (this is specifically for the value with the spaces between “2HZRE” and “+” and “4” and “HR”… the others appear to be working)
>
> For the free-text values that can’t be mapped, adding a free text field on the new form is a bigger discussion, but I think as part of this ticket we should at least set the “anti-TB treatment” radio set to have “yes” checked… as this makes it clearer that the patient is at least on TB treatment