### PR TITLE
Use datetime instead of timestamp for patient_created_date

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/PatientMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/PatientMigrator.groovy
@@ -25,7 +25,7 @@ class PatientMigrator extends SqlMigrator {
                 birth_place varchar(255),
                 accompagnateur_name varchar(255),
                 patient_created_by int,
-                patient_created_date timestamp,
+                patient_created_date datetime,
                 outcome varchar(255),
                 outcome_date date,
                 zone varchar(32),

--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/RegistrationMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/RegistrationMigrator.groovy
@@ -45,7 +45,7 @@ class RegistrationMigrator extends ObsMigrator {
                         hivmigration_users hu on p.patient_created_by = hu.source_user_id
                     left join
                         users u on u.uuid = hu.user_uuid;
-            ''');
+            ''')
 
         setAutoIncrement("hivmigration_patient_birthplace", "(select max(obs_id)+1 from obs)")
 


### PR DESCRIPTION
Should resolve https://pihemr.atlassian.net/browse/UHM-5075

The problem was actually upstream: the registration encounter_date was being set to the patient_created_date, but the patient_created_date wasn't being loaded correctly from the HIV_DEMOGRAPHICS table. All patients currently have `created_date` equal to the migration date.

I'll merge once I do an end-to-end run.