### PR TITLE
move Adverse Events migrator to run after the ObsLoadingMigrator has run

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/Migrator.java
@@ -128,7 +128,6 @@ public class Migrator {
                 migrate(new RegistrationMigrator(), limit);
                 migrate(new ProgramMigrator(), limit);
                 migrate(new ProviderMigrator(), limit);
-                migrate(new AdverseEventMigrator(), limit);
                 migrate(new LabResultMigrator(), limit);
                 migrate(new SocioEconomicsMigrator(), limit);
                 migrate(new FormsMigrator(), limit);
@@ -144,6 +143,7 @@ public class Migrator {
                 migrate(new ExamLabResultsMigrator(), limit);
                 migrate(new PcrTestsMigrator(), limit);
                 migrate(new ObsLoadingMigrator(), limit);
+                migrate(new AdverseEventMigrator(), limit);
                 migrate(new AdherenceMigrator(), -1);
                 migrate(new NutritionMigrator(), -1);
                 migrate(new TreatmentObsMigrator(), limit);


### PR DESCRIPTION
@brandones looks like the migration has been failing over the weekend... a quick glance and it looks like it's just because the adverse events migrator is running before the obs loading migrator and depends on it.  Going to merge this pull request and see if it fixes things, otherwise will likely just revert the AdverseEvent PRs