### PR TITLE
Add index to tmp_obs.obs_group_id supporting the query in TreatmentObs:migrateArtStatus - 'Add codifiable values...'

### DIFF
--- a/etl/src/main/java/org/pih/hivmigration/etl/sql/TreatmentObsMigrator.groovy
+++ b/etl/src/main/java/org/pih/hivmigration/etl/sql/TreatmentObsMigrator.groovy
@@ -643,6 +643,10 @@ class TreatmentObsMigrator extends ObsMigrator {
             WHERE value_uuid IS NOT NULL;
         ''')
 
+        executeMysql("Add index to tmp_obs.obs_group_id to support the next step", '''
+            CREATE INDEX obs_group_id_idx ON tmp_obs (`obs_group_id`);
+        ''')
+
         executeMysql("Add codifiable values that were put in 'other', if there's not already a coded value", '''
             INSERT INTO tmp_obs (source_encounter_id, concept_uuid, value_coded_uuid, obs_group_id)
             SELECT arv.source_encounter_id,


### PR DESCRIPTION
Speeds up "Add codifiable values that were put in 'other', if there's not already a coded value." See [the last build](http://bamboo.pih-emr.org:8085/download/HIVM-EMJ-JOB1/build_logs/HIVM-EMJ-JOB1-256.log), where that one query took 50 mins.